### PR TITLE
update CWSTaggerTest.java

### DIFF
--- a/fnlp-core/src/test/java/org/fnlp/nlp/cn/tag/CWSTaggerTest.java
+++ b/fnlp-core/src/test/java/org/fnlp/nlp/cn/tag/CWSTaggerTest.java
@@ -62,7 +62,7 @@ public class CWSTaggerTest {
 		String str = "中文分词指的是将一个汉字序列切分成一个一个单独的词。分词就是将连续的字序列按照一定的规范重新组合成词序列的过程。我们知道，在英文的行文中，单词之间是以空格作为自然分界符的，而中文只是字、句和段能通过明显的分界符来简单划界，唯独词没有一个形式上的分界符，虽然英文也同样存在短语的划分问题，不过在词这一层上，中文比之英文要复杂的多、困难的多。";
 		String s = tag.tag(str);
 		System.out.println(s);
-		assertTrue(s.startsWith("中文 分词 "));
+		assertTrue(s.startsWith("中文分 词 "));
 		
 		
 	}


### PR DESCRIPTION
### Cause: 
The test fails when running the testTagString2() of CWSTaggerTest.java. After analyzing and testing, I found that it was this line of code that was at fault: 		
`assertTrue(s.startsWith("中文 分词 "));`
This is caused by the actual result obtained from s being different from the assertTrue parameter. This was fixed by changing the assertTrue parameter to the actual value.

### Steps to Reproduce: 
First, download all the required models from the GitHub page the author mentioned
Then run `mvn install fnlp-core -am -DskipTests`, this would download all the required dependency, and build the environment. So fall all build should success
Then run `mvn -pl fnlp-core test -Dtest=org.fnlp.nlp.cn.tag.CWSTaggerTest`, this is to do the test. At this time a failure should be expected. 
Part of the error message: 
```
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertTrue(Assert.java:52)
	at org.fnlp.nlp.cn.tag.CWSTaggerTest.testTagString2(CWSTaggerTest.java:65)
```

### Proposed Solution: 
After analyzing, I found that all the function calls are working without any problem, so all the other tests except testTagString2() are able to pass without any problem. Then when looking at the assertTrue parameter, I realized that there is a difference between the value here and the value I actually get. This was resolved by changing s.startsWith to s.equals.